### PR TITLE
Update compojure version to latest

### DIFF
--- a/src/leiningen/new/compojure_app/project.clj
+++ b/src/leiningen/new/compojure_app/project.clj
@@ -2,7 +2,7 @@
   :description "FIXME: write description"
   :url "http://example.com/FIXME"
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [compojure "1.1.5"]
+                 [compojure "1.1.6"]
                  [hiccup "1.0.4"]
                  [ring-server "0.3.0"]]
   :plugins [[lein-ring "0.8.7"]]


### PR DESCRIPTION
Changing the version number to 1.1.6, the latest.  This solves an issue where 1.1.5 pulls in an OLD version of ring/ring-core.  This causes issues with other common dependencies like `cemerick.friend`.  The alternative is to explicitly specify `[ring/ring-core "1.2.0"]` as a dependency.

I made the change locally, installed the template and was able to `lein new compojure-app` and get a working repl and server.
